### PR TITLE
fix build errors on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,11 @@ MWLD_VERSION := 2.7
 ifeq ($(WINDOWS),1)
   WINE :=
 else
-  WINE := wine
+  WINE ?= wine
 endif
 AS      := $(DEVKITPPC)/bin/powerpc-eabi-as
 OBJCOPY := $(DEVKITPPC)/bin/powerpc-eabi-objcopy
-CPP     := $(DEVKITPPC)/bin/powerpc-eabi-cpp.exe -P
+CPP     := $(DEVKITPPC)/bin/powerpc-eabi-cpp -P
 CC      := $(WINE) tools/mwcc_compiler/$(MWCC_VERSION)/mwcceppc.exe
 LD      := $(WINE) tools/mwcc_compiler/$(MWLD_VERSION)/mwLinkPatch.exe
 ELF2DOL := tools/elf2dol

--- a/tools/postprocess.py
+++ b/tools/postprocess.py
@@ -267,7 +267,7 @@ def postprocess_elf(f, do_ctor_realign, do_old_stack, do_symbol_fixup):
             print("Patched ctors + dtors")
 
     f.seek(0)
-    f.write(bytes(source_bytes))
+    f.write(bytearray(source_bytes))
 
 def frontend(args):
     inplace = ""


### PR DESCRIPTION
* Made it so that the Makefile respects the `WINE` environment variable, allowing you to choose what version of Wine to use.
* Removed .exe suffix on cpp tool.
* postprocess.py was outputting a string representation of the array instead of raw binary data. Using bytearray fixed this.